### PR TITLE
Fix p4tenant remove to support deleting individual VMs

### DIFF
--- a/p4tenant/src/p4tenant/cli.py
+++ b/p4tenant/src/p4tenant/cli.py
@@ -782,11 +782,13 @@ def remove(
         print_warning(f"No VMs found matching '{username}' in restsrv01.yaml")
 
     # 2. Show config file changes and ask about updating them
-    config_changes = manager.remove_tenant(username, dry_run=True)
+    config_changes = manager.remove_tenant(username, vm_names=selected_vms, dry_run=True)
     if config_changes:
         # Add admin inventories that will be modified
         for inv_file in BASE_DIR.glob("inventory-*.yaml"):
-            config_changes.append((inv_file.name, f"Remove '{vm_name}' if present"))
+            # Show removal for each selected VM
+            for selected_vm in selected_vms:
+                config_changes.append((inv_file.name, f"Remove '{selected_vm}' if present"))
 
     should_update_config = not skip_config
     if config_changes and not skip_config:
@@ -833,12 +835,13 @@ def remove(
     # Update configuration files
     if should_update_config:
         console.print("[dim]Removing tenant from configuration files...[/dim]")
-        manager.remove_tenant(username, dry_run=False)
+        manager.remove_tenant(username, vm_names=selected_vms, dry_run=False)
 
-        # Remove from admin inventories
-        modified_invs = remove_from_admin_inventories(vm_name)
-        for inv_path in modified_invs:
-            print_success(f"Removed from {inv_path.name}")
+        # Remove from admin inventories (for each selected VM)
+        for selected_vm in selected_vms:
+            modified_invs = remove_from_admin_inventories(selected_vm)
+            for inv_path in modified_invs:
+                print_success(f"Removed from {inv_path.name}")
 
         print_success(f"Configuration files updated for '{username}'")
     else:


### PR DESCRIPTION
## Summary

Fixes #1 - The p4tenant remove command now correctly supports deleting individual VMs instead of removing all VMs or the wrong VM.

## Problem

When trying to remove `restvm-mspina-02`, the tool would:
- Remove the entire user `mspina` from restart_users
- Only remove `restvm-mspina-01` from configuration files
- The CLI's VM selection feature was ignored

## Solution

1. **Updated `TenantManager.remove_tenant()`** to accept an optional `vm_names` parameter
   - Defaults to removing all VMs if not specified (backward compatible)
   - Only removes user from `restart_users` when ALL their VMs are being deleted
   - Processes each VM in the provided list

2. **Updated CLI `remove` command** to pass selected VMs to the method
   - The VM selection prompt now actually controls which VMs are removed
   - Admin inventories are updated for each selected VM

## Changes to apply

The "Changes to apply" UI now correctly shows:
- Individual VMs being removed (not just VM-01)
- Whether the user will be removed from restart_users (only if all VMs deleted)
- Separate entries for each selected VM in admin inventories

## Test plan

- [ ] Test removing a single VM from a user with multiple VMs (e.g., remove `restvm-mspina-02` while keeping `-01`)
- [ ] Verify user remains in `restart_users` when some VMs remain
- [ ] Test removing all VMs for a user - verify user is removed from `restart_users`
- [ ] Test removing the only VM for a user - verify complete cleanup
- [ ] Verify "Changes to apply" displays correct VMs being removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)