### PR TITLE
Fix VM and IP alignment in tenant list output

### DIFF
--- a/p4tenant/src/p4tenant/tenant.py
+++ b/p4tenant/src/p4tenant/tenant.py
@@ -353,15 +353,18 @@ class TenantManager:
         all_srv_vms = srv_data.get("vms", [])
         in_vms_list = any(vm in all_srv_vms for vm in user_vms)
 
-        # Aggregate IPs from all user's VMs
+        # Aggregate IPs from all user's VMs (both flat list and grouped by VM)
         ips = []
+        vm_ip_map = {}  # Map of vm_name -> list of IPs
         has_host_vars = False
         for vm_name in user_vms:
             host_vars_path = get_host_vars_path(vm_name)
             if host_vars_path.exists():
                 has_host_vars = True
                 hv_data = load_yaml(host_vars_path)
-                ips.extend(hv_data.get("dataplane_ipv4", []))
+                vm_ips = hv_data.get("dataplane_ipv4", [])
+                ips.extend(vm_ips)
+                vm_ip_map[vm_name] = vm_ips
 
         # Check inventory
         inv_data = load_yaml(INVENTORY_FILE)
@@ -380,6 +383,7 @@ class TenantManager:
             "vm_name": primary_vm,
             "vm_names": user_vms,
             "ips": ips,
+            "vm_ip_map": vm_ip_map,  # Map of vm_name -> list of IPs for proper alignment
             "in_restart_users": in_restart_users,
             "in_vms_list": in_vms_list,
             "in_inventory": in_inventory,

--- a/p4tenant/src/p4tenant/ui.py
+++ b/p4tenant/src/p4tenant/ui.py
@@ -89,14 +89,40 @@ def create_tenant_table(tenants: list[dict]) -> Table:
             status_parts.append("[red]\u2717 host[/red]")
 
         status = " ".join(status_parts)
-        ips = "\n".join(tenant.get("ips", []))
 
-        # Show VM names (or count if multiple)
+        # Get VM names and IP mapping
         vm_names = tenant.get("vm_names", [])
+        vm_ip_map = tenant.get("vm_ip_map", {})
+
+        # Build aligned VM and IP displays
         if len(vm_names) <= 1:
+            # Single VM - simple display
             vms_display = tenant.get("vm_name", "")
+            ips = "\n".join(tenant.get("ips", []))
         else:
-            vms_display = "\n".join(vm_names)
+            # Multiple VMs - align IPs with their VMs
+            vm_lines = []
+            ip_lines = []
+
+            for vm_name in vm_names:
+                vm_ips = vm_ip_map.get(vm_name, [])
+
+                if vm_ips:
+                    # First line: VM name and first IP
+                    vm_lines.append(vm_name)
+                    ip_lines.append(vm_ips[0])
+
+                    # Remaining IPs for this VM: blank VM name, show IP
+                    for ip in vm_ips[1:]:
+                        vm_lines.append("")
+                        ip_lines.append(ip)
+                else:
+                    # No IPs for this VM
+                    vm_lines.append(vm_name)
+                    ip_lines.append("")
+
+            vms_display = "\n".join(vm_lines)
+            ips = "\n".join(ip_lines)
 
         table.add_row(
             tenant.get("username", ""),


### PR DESCRIPTION
## Summary

Fixes #2 - Corrects the misalignment of VM names and their corresponding IP addresses in the `p4tenant list` command output.

## Problem

When displaying tenants with multiple VMs (e.g., user `mspina` with `restvm-mspina-01` and `restvm-mspina-02`), the IP addresses were not correctly aligned with their VM names. All IPs from all VMs were displayed in sequence without grouping, causing visual misalignment where the second VM name would appear next to an IP address from the first VM.

**Before:**
```
restvm-mspina-01    10.10.0.21/24
restvm-mspina-02    10.10.0.22/24
                    10.10.0.11/24
                    10.10.0.12/24
```

## Solution

Modified the tenant information structure and table rendering logic to:

1. **In `tenant.py`**: Added `vm_ip_map` dictionary to `get_tenant_info()` that maps each VM name to its list of IP addresses, preserving the association between VMs and their IPs.

2. **In `ui.py`**: Updated `create_tenant_table()` to use the `vm_ip_map` for proper alignment:
   - For tenants with multiple VMs, iterate through each VM
   - Display the VM name with its first IP on the same line
   - Show remaining IPs for that VM on subsequent lines with blank VM names
   - Then move to the next VM

**After:**
```
restvm-mspina-01    10.10.0.21/24
                    10.10.0.22/24
restvm-mspina-02    10.10.0.11/24
                    10.10.0.12/24
```

## Testing

Tested with the current configuration where user `mspina` has two VMs, each with 2 IP addresses. The alignment now correctly groups each VM with its corresponding IPs.

## Files Changed

- `p4tenant/src/p4tenant/tenant.py`: Added `vm_ip_map` to tenant info structure
- `p4tenant/src/p4tenant/ui.py`: Implemented proper alignment logic in table rendering

🤖 Generated with [Claude Code](https://claude.com/claude-code)